### PR TITLE
Bugfix in converter

### DIFF
--- a/svelte/src/routes/v2/+page.svelte
+++ b/svelte/src/routes/v2/+page.svelte
@@ -65,7 +65,7 @@
 			if(doRecreateWholeGraphData){
 				graphData = createGraphData(convertedData);
 				doRecreateWholeGraphData = false;
-				
+				doRefilter = true;
 			}
             if (doRefilter) {
 				filter(config, graphData);

--- a/svelte/src/routes/v2/types/index.ts
+++ b/svelte/src/routes/v2/types/index.ts
@@ -9,7 +9,7 @@ export interface ConfigInterface {
 
 export interface ConvertedNode {
 	id: string;
-	members?: ConvertedNode[];
+	members: ConvertedNode[];
 	parentId?: string;
 	level: number;
 }
@@ -26,6 +26,7 @@ export interface ConvertedEdge {
 }
 
 export enum EdgeType {
+	// (in retrospect, this might not need to be an enum)
 	contains = 'contains',
 	constructs = 'constructs',
 	holds = 'holds',
@@ -34,7 +35,17 @@ export enum EdgeType {
 	specializes = 'specializes',
 	returns = 'returns',
 	accesses = 'accesses',
-	creates = 'creates'
+	creates = 'creates',
+	exhibits = 'exhibits',
+	invokes = 'invokes',
+	type = 'type',
+	hasVariable = 'hasVariable',
+	hasParameter = 'hasParameter',
+	hasScript = 'hasScript',
+	returnType = 'returnType',
+	instantiates = 'instantiates',
+	// Temp fix, some of our input data does not have the edge type.
+	unknown = 'UNKNOWN', 
 }
 
 export interface ConvertedData {

--- a/svelte/src/routes/v2/types/raw-data.ts
+++ b/svelte/src/routes/v2/types/raw-data.ts
@@ -21,7 +21,8 @@ export interface RawEdgeType {
 		id: string;
 		source: string;
 		target: string;
-		label: string;
+		label?: string; // Does the same as labels
+		labels?: string[];
 		properties: {
 			containmentType?: string;
 			weight: number;


### PR DESCRIPTION
Removing nodes from the nodesdictionary caused links to be sometimes unable to find their source and target, depening on the order of the links (Also, the current version forgot to remove the sub-nodes from the list of root nodes).