### PR TITLE
Save last zoom before reset

### DIFF
--- a/svelte/src/routes/v2/+page.svelte
+++ b/svelte/src/routes/v2/+page.svelte
@@ -27,7 +27,7 @@
 		minimumVertexSize: 50,
 		shownEdgesType: new Map<EdgeType, boolean>()
 	};
-	let svgElement: any = {};
+	let svgElement: SVGElement | undefined = undefined;
 
 	let doReconvert = true;
 	let doRecreateWholeGraphData = true;
@@ -83,7 +83,7 @@
 			}
 			if (doRedraw) {
 				// remove the old data
-				cleanCanvas(svgElement, simulations);
+				cleanCanvas(svgElement!, simulations);
 
 				let result = draw(
 					svgElement,

--- a/svelte/src/routes/v2/scripts/clean-canvas/index.ts
+++ b/svelte/src/routes/v2/scripts/clean-canvas/index.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-export function cleanCanvas(svgElement: any, simulations: any) {
+export function cleanCanvas(svgElement: SVGElement, simulations: any) {
 	// remove all simulations and forces
 	simulations.forEach((simulation: any) => {
 		simulation.stop();

--- a/svelte/src/routes/v2/scripts/draw/index.ts
+++ b/svelte/src/routes/v2/scripts/draw/index.ts
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import { innerTicked, linkTicked, masterSimulationTicked } from './tick';
 import { dragEndedNode, dragStartedNode, draggedNode } from './drag-handler';
 import { setupGradient } from './gradient-setup';
-import type { ConfigInterface } from '../../types';
+import type { ConfigInterface, DrawSettingsInterface } from '../../types';
 
 const SVGSIZE = 800;
 const SVGMARGIN = 50;
@@ -12,7 +12,7 @@ function createInnerSimulation(
 	canvas: any,
 	allSimulation: any,
 	parentNode: any,
-	drawSettings: any
+	drawSettings: DrawSettingsInterface,
 ) {
 	// use this instead of forEach so that it is passed by reference.
 
@@ -76,9 +76,9 @@ export function draw(
 	svgElement: any,
 	graphData: any,
 	config: ConfigInterface,
-	drawSettings: any,
+	drawSettings: DrawSettingsInterface,
 	onCollapse: any,
-	onLift: any
+	onLift: any,
 ) {
 	const simulations: any = [];
 
@@ -207,10 +207,19 @@ export function draw(
 			.scaleExtent([1, 8])
 			.on('zoom', ({ transform }) => {
 				canvas.attr('transform', transform);
+				drawSettings.transformation = transform;
 			})
 	);
+
+	//Reload last transformation, if avaidable
+	if (drawSettings.transformation) {
+		// (The type of this method is incorrect, annoyingly)
+		canvas.attr('transform', drawSettings.transformation as any)
+	}
+
+
 	return {
 		simulations,
-		svgElement
+		svgElement,
 	};
 }

--- a/svelte/src/routes/v2/types/index.ts
+++ b/svelte/src/routes/v2/types/index.ts
@@ -7,6 +7,12 @@ export interface ConfigInterface {
 	collapsedVertices: any[];
 }
 
+export interface DrawSettingsInterface{
+	minimumVertexSize: number, 
+	shownEdgesType: Map<EdgeType, boolean>,
+	transformation?: {k: number, x: number, y: number}; // Used to remember the last transformation in-between redraws.
+}
+
 export interface ConvertedNode {
 	id: string;
 	members: ConvertedNode[];


### PR DESCRIPTION
Turned out to be surprisingly simple.

We might want to upgrade this requirement to also remember the node positioning, but that would be after Christoffer fixed the node-drawing.