### PR TITLE
Feat/nested layout

### DIFF
--- a/svelte/.eslintrc.cjs
+++ b/svelte/.eslintrc.cjs
@@ -3,7 +3,9 @@ module.exports = {
 		// allow explicit any
 		'@typescript-eslint/no-explicit-any': 'off',
 		// allow unused vars
-		'@typescript-eslint/no-unused-vars': 'off'
+		'@typescript-eslint/no-unused-vars': 'off',
+		// allow ts-ignore pragma 
+		'@typescript-eslint/ban-ts-comment': 'off',
 	},
 	root: true,
 	extends: [

--- a/svelte/src/routes/v2/+page.svelte
+++ b/svelte/src/routes/v2/+page.svelte
@@ -92,7 +92,7 @@
 				cleanCanvas(svgElement!, simulations);
 
 				let result = draw(
-					svgElement,
+					svgElement!,
 					graphData,
 					config,
 					drawSettings,

--- a/svelte/src/routes/v2/scripts/draw/custom-d3-forces.ts
+++ b/svelte/src/routes/v2/scripts/draw/custom-d3-forces.ts
@@ -8,46 +8,6 @@ interface simluationNodeDatumType extends SimulationNodeDatum {
     cy?: number,
 }
 
-interface point {
-    x: number,
-    y: number,
-}
-
-interface squareData {
-    topleft: point,
-    bottomright: point,
-    middle: point,
-    width: number,
-    height: number,
-}
-
-function makeSquare(node: simluationNodeDatumType): squareData {
-    const topLeftx = node.x! + node.cx!;
-    const topLefty = node.y! + node.cy!;
-    return {
-        topleft: { // Coordinates of top-left point
-            x: topLeftx,
-            y: topLefty,
-        },
-        bottomright: { // Coordinates of bottomright point
-            x: topLeftx + node.width,
-            y: topLefty + node.height,
-        },
-        middle: {
-            x: topLeftx + node.width,
-            y: topLefty + node.height,
-        },
-        width: node.width,
-        height: node.height,
-    };
-};
-
-function calcForceStrength(node1: squareData, node2: squareData, alpha: number) {
-    return (node1.width + node1.height) / (node1.width + node1.height + node2.width + node2.height)
-        * (1 + alpha)
-        * 5; // random magic number
-}
-
 /**
  * Creates a rectangular collison force across all nodes
  * 
@@ -55,6 +15,48 @@ function calcForceStrength(node1: squareData, node2: squareData, alpha: number) 
  */
 export function rectangleCollideForce(): Force<simluationNodeDatumType, any>  {
     let nodes: simluationNodeDatumType[];
+
+    interface point {
+        x: number,
+        y: number,
+    }
+    
+    interface squareData {
+        topleft: point,
+        bottomright: point,
+        middle: point,
+        width: number,
+        height: number,
+    }
+    
+    function makeSquare(node: simluationNodeDatumType): squareData {
+        const topLeftx = node.x! + node.cx!;
+        const topLefty = node.y! + node.cy!;
+        return {
+            topleft: { // Coordinates of top-left point
+                x: topLeftx,
+                y: topLefty,
+            },
+            bottomright: { // Coordinates of bottomright point
+                x: topLeftx + node.width,
+                y: topLefty + node.height,
+            },
+            middle: {
+                x: topLeftx + node.width,
+                y: topLefty + node.height,
+            },
+            width: node.width,
+            height: node.height,
+        };
+    };
+    
+    function calcForceStrength(node1: squareData, node2: squareData, alpha: number) {
+        return (node1.width + node1.height) / (node1.width + node1.height + node2.width + node2.height)
+            * (1 + alpha)
+            * 5; // random magic number
+    }
+
+    // actual force calulation
 	function force(alpha: number) {
         // Loop through all nodes for collision check
 		for (let i = 0; i < nodes.length; i++) {
@@ -119,17 +121,17 @@ export function rectangleCollideForce(): Force<simluationNodeDatumType, any>  {
  * 
  */
 export function radialClampForce(
-    x: () => number, 
-    y: () => number,
     r: () => number, 
 ): Force<simluationNodeDatumType, any> {
     let nodes: simluationNodeDatumType[]; 
-    // Unused, might want to set this to false after drag.
+    // Unused, might want to set this to false after dragging a node.
+    // Might also want to have this set to false at the start of a simluation.
     const clamp = true;
 
+
     function force(alpha: number) {
-        const cx = x();
-        const cy = y();
+        const cx = r();
+        const cy = r();
         const radius = r();
         if (!Number.isNaN(cx) && !Number.isNaN(cy) && !Number.isNaN(radius)) {
             nodes.forEach(node => {

--- a/svelte/src/routes/v2/scripts/draw/custom-d3-forces.ts
+++ b/svelte/src/routes/v2/scripts/draw/custom-d3-forces.ts
@@ -1,42 +1,91 @@
+
 import type {SimulationNodeDatum} from "d3";
 
 interface simluationNodeDatumType extends SimulationNodeDatum {
     width: number,
     height: number,
+    cx?: number,
+    cy?: number,
 }
 
-export function squareCollideForce(nodes: simluationNodeDatumType[]) {
+interface point {
+    x: number,
+    y: number,
+}
+
+interface squareData {
+    topleft: point,
+    bottomright: point,
+    middle: point,
+    width: number,
+    height: number,
+}
+
+function makeSquare(node: simluationNodeDatumType): squareData {
+    const topLeftx = node.x! + node.cx!;
+    const topLefty = node.y! + node.cy!;
+    return {
+        topleft: { // Coordinates of top-left point
+            x: topLeftx,
+            y: topLefty,
+        },
+        bottomright: { // Coordinates of bottomright point
+            x: topLeftx + node.width,
+            y: topLefty + node.height,
+        },
+        middle: {
+            x: topLeftx + node.width,
+            y: topLefty + node.height,
+        },
+        width: node.width,
+        height: node.height,
+    };
+};
+
+function calcForceStrength(node1: squareData, node2: squareData, alpha: number) {
+    return (node1.width + node1.height) / (node1.width + node1.height + node2.width + node2.height)
+        * (1 + alpha)
+        * 5; // random magic number
+}
+
+export function rectangleCollideForce(nodes: simluationNodeDatumType[]) {
 	return function (alpha: number) {
-        //Collision detection (Not as bad as it looks, this force only applies locally)
+        // Loop through all nodes for collision check
 		for (let i = 0; i < nodes.length; i++) {
 			for (let j = i + 1; j < nodes.length; j++) {
-                const node1 = nodes[i];
-				const node2 = nodes[j];
-                if (node1.x && node1.y && node2.x && node2.y) {    
-                    if (node1.x + node1.width >= node2.x && node1.x <= node2.x + node2.width && 
-                        node1.y + node1.height >= node2.y && node1.y <= node2.y + node2.height) {
-                        // We collided
+                if (nodes[i].x && nodes[i].y && nodes[j].x && nodes[j].y) {
 
-                        // Calculate force strength (We want movement to go somewhat smooth)
-                        const distance = Math.sqrt( Math.abs(node1.x - node2.x)**2 +  Math.abs(node1.y - node2.y)**2);
-                        const verticalForceStrength = Math.max(node1.height, node2.height)*5*(1-alpha) / distance 
-                        const horizontalForceStrength = Math.max(node1.width, node2.width)*5*(1-alpha) / distance 
+                    // Caclulate x and y position of the top-left and bottom-right corner of the node, and middle position.
+                    const node1 = makeSquare(nodes[i]);
+				    const node2 = makeSquare(nodes[j]);
+                    
+                    // Check for collision
+                    if (node1.bottomright.x >= node2.topleft.x && node1.topleft.x <= node2.bottomright.x && 
+                        node1.bottomright.y >= node2.topleft.y && node1.topleft.y <= node2.bottomright.y) {
 
-                        // Update node positions
-                        if (node1.x < node2.x) {
-                            node1.vx! -= horizontalForceStrength;
-                            node2.vx! += horizontalForceStrength;
+                        // We collided!
+                        // We want small nodes to move out of the way for large nodes
+                        // Also, the strenght of the force should decrease with alpha
+                        const n1ForceStrength = calcForceStrength(node1, node2, alpha);
+                        const n2ForceStrength = calcForceStrength(node2, node1, alpha);
+
+                        // Trig stuff to calculate the direction of the force-vector
+                        const delta = (node1.middle.y-node2.middle.y)/(node1.middle.x-node2.middle.x)
+                        const angle = Math.atan(delta);
+                        const vy = Math.sin(angle);
+                        const vx = Math.cos(angle);
+
+                        // Set the values
+                        if (node1.middle.x > node2.middle.x) {
+                            nodes[i].vx! += vx * n1ForceStrength;
+                            nodes[i].vy! += vy * n1ForceStrength;
+                            nodes[j].vx! -= vx * n2ForceStrength;
+                            nodes[j].vy! -= vy * n2ForceStrength;
                         } else {
-                            node1.vx! += horizontalForceStrength;
-                            node2.vx! -= horizontalForceStrength;
-                        }
-
-                        if (node1.y < node2.y) {
-                            node1.vy! -= verticalForceStrength;
-                            node2.vy! += verticalForceStrength;
-                        } else {
-                            node1.vy! += verticalForceStrength;
-                            node2.vy! -= verticalForceStrength;
+                            nodes[i].vx! -= vx * n1ForceStrength;
+                            nodes[i].vy! -= vy * n1ForceStrength;
+                            nodes[j].vx! += vx * n2ForceStrength;
+                            nodes[j].vy! += vy * n2ForceStrength;
                         }
                     }
                 }

--- a/svelte/src/routes/v2/scripts/draw/custom-d3-forces.ts
+++ b/svelte/src/routes/v2/scripts/draw/custom-d3-forces.ts
@@ -1,0 +1,46 @@
+import type {SimulationNodeDatum} from "d3";
+
+interface simluationNodeDatumType extends SimulationNodeDatum {
+    width: number,
+    height: number,
+}
+
+export function squareCollideForce(nodes: simluationNodeDatumType[]) {
+	return function (alpha: number) {
+        //Collision detection (Not as bad as it looks, this force only applies locally)
+		for (let i = 0; i < nodes.length; i++) {
+			for (let j = i + 1; j < nodes.length; j++) {
+                const node1 = nodes[i];
+				const node2 = nodes[j];
+                if (node1.x && node1.y && node2.x && node2.y) {    
+                    if (node1.x + node1.width >= node2.x && node1.x <= node2.x + node2.width && 
+                        node1.y + node1.height >= node2.y && node1.y <= node2.y + node2.height) {
+                        // We collided
+
+                        // Calculate force strength (We want movement to go somewhat smooth)
+                        const distance = Math.sqrt( Math.abs(node1.x - node2.x)**2 +  Math.abs(node1.y - node2.y)**2);
+                        const verticalForceStrength = Math.max(node1.height, node2.height)*5*(1-alpha) / distance 
+                        const horizontalForceStrength = Math.max(node1.width, node2.width)*5*(1-alpha) / distance 
+
+                        // Update node positions
+                        if (node1.x < node2.x) {
+                            node1.vx! -= horizontalForceStrength;
+                            node2.vx! += horizontalForceStrength;
+                        } else {
+                            node1.vx! += horizontalForceStrength;
+                            node2.vx! -= horizontalForceStrength;
+                        }
+
+                        if (node1.y < node2.y) {
+                            node1.vy! -= verticalForceStrength;
+                            node2.vy! += verticalForceStrength;
+                        } else {
+                            node1.vy! += verticalForceStrength;
+                            node2.vy! -= verticalForceStrength;
+                        }
+                    }
+                }
+			}
+		}
+	};
+}

--- a/svelte/src/routes/v2/scripts/draw/index.ts
+++ b/svelte/src/routes/v2/scripts/draw/index.ts
@@ -3,7 +3,7 @@ import { innerTicked, linkTicked, masterSimulationTicked } from './tick';
 import { dragEndedNode, dragStartedNode, draggedNode } from './drag-handler';
 import { setupGradient } from './gradient-setup';
 import type { ConfigInterface, DrawSettingsInterface } from '../../types';
-import { squareCollideForce } from './custom-d3-forces';
+import { rectangleCollideForce } from './custom-d3-forces';
 
 const SVGSIZE = 800;
 const SVGMARGIN = 50;
@@ -33,7 +33,7 @@ function createInnerSimulation(
 	innerSimulation.force('charge', d3.forceManyBody().strength(-300));
 	innerSimulation.force('x', d3.forceX());
 	innerSimulation.force('y', d3.forceY());
-	innerSimulation.force('collide', squareCollideForce(nodes));
+	innerSimulation.force('collide', rectangleCollideForce(nodes));
 
 	allSimulation.push(innerSimulation);
 
@@ -160,7 +160,7 @@ export function draw(
 	simulation.force('charge', d3.forceManyBody().strength(-3000));
 	simulation.force('x', d3.forceX(SVGSIZE / 2));
 	simulation.force('y', d3.forceY(SVGSIZE / 2));
-	simulation.force('collide', squareCollideForce(graphData.nodes))
+	simulation.force('collide', rectangleCollideForce(graphData.nodes))
 	simulation.on('tick', () => {
 		masterSimulationTicked(
 			graphData,

--- a/svelte/src/routes/v2/scripts/draw/index.ts
+++ b/svelte/src/routes/v2/scripts/draw/index.ts
@@ -3,6 +3,7 @@ import { innerTicked, linkTicked, masterSimulationTicked } from './tick';
 import { dragEndedNode, dragStartedNode, draggedNode } from './drag-handler';
 import { setupGradient } from './gradient-setup';
 import type { ConfigInterface, DrawSettingsInterface } from '../../types';
+import { squareCollideForce } from './custom-d3-forces';
 
 const SVGSIZE = 800;
 const SVGMARGIN = 50;
@@ -32,6 +33,7 @@ function createInnerSimulation(
 	innerSimulation.force('charge', d3.forceManyBody().strength(-300));
 	innerSimulation.force('x', d3.forceX());
 	innerSimulation.force('y', d3.forceY());
+	innerSimulation.force('collide', squareCollideForce(nodes));
 
 	allSimulation.push(innerSimulation);
 
@@ -158,6 +160,7 @@ export function draw(
 	simulation.force('charge', d3.forceManyBody().strength(-3000));
 	simulation.force('x', d3.forceX(SVGSIZE / 2));
 	simulation.force('y', d3.forceY(SVGSIZE / 2));
+	simulation.force('collide', squareCollideForce(graphData.nodes))
 	simulation.on('tick', () => {
 		masterSimulationTicked(
 			graphData,
@@ -168,7 +171,7 @@ export function draw(
 			collapseButtonElements,
 			liftButtonElements
 		);
-	});
+	})
 
 	simulations.push(simulation);
 
@@ -243,7 +246,7 @@ export function draw(
 		.attr('cx', drawSettings.buttonRadius)
 		.attr('cy', 0)
 		.attr('fill', ({ id }: any) => {
-			if (config.dependencyLifting.find(({ nodeId }) => nodeId === id)) {
+			if (config.dependencyLifting.find(({ node }) => node.id === id)) {
 				return 'aqua';
 			}
 			return 'blue';
@@ -320,7 +323,7 @@ export function draw(
 				[0, 0],
 				[SVGSIZE + SVGMARGIN * 2, SVGSIZE + SVGMARGIN * 2]
 			])
-			.scaleExtent([1, 8])
+			//.scaleExtent([1, 8]) Our dataset is way larger
 			.on('zoom', ({ transform }) => {
 				canvas.attr('transform', transform);
 				drawSettings.transformation = transform;

--- a/svelte/src/routes/v2/scripts/draw/index.ts
+++ b/svelte/src/routes/v2/scripts/draw/index.ts
@@ -14,8 +14,8 @@ function toHTMLToken(string: string) {
 function createInnerSimulation(
 	level: number,
 	nodes: any,
-	canvas: any,
-	allSimulation: any,
+	canvas: d3.Selection<SVGGElement, unknown, null, undefined>,
+	allSimulation: d3.Simulation<d3.SimulationNodeDatum, undefined>[],
 	parentNode: any,
 	drawSettings: DrawSettingsInterface,
 	onCollapse: any,
@@ -58,6 +58,7 @@ function createInnerSimulation(
 			.text((d: any) => d.id);
 	}
 	membersContainerElement.call(
+		//@ts-ignore
 		d3
 			.drag()
 			.on('start', (d) => {
@@ -137,14 +138,14 @@ function createInnerSimulation(
 }
 
 export function draw(
-	svgElement: any,
+	svgElement: SVGElement,
 	graphData: any,
 	config: ConfigInterface,
 	drawSettings: DrawSettingsInterface,
 	onCollapse: (datum: any) => void,
 	onLift: (datum: any) => void,
 ) {
-	const simulations: any = [];
+	const simulations: d3.Simulation<d3.SimulationNodeDatum, undefined>[] = [];
 
 	const svg = d3
 		.select(svgElement)
@@ -312,6 +313,7 @@ export function draw(
 
 	// Add zoom handler
 	svg.call(
+		//@ts-ignore
 		d3
 			.zoom()
 			.extent([

--- a/svelte/src/routes/v2/scripts/draw/index.ts
+++ b/svelte/src/routes/v2/scripts/draw/index.ts
@@ -32,15 +32,14 @@ function createInnerSimulation(
 	const innerSimulation = d3.forceSimulation(nodes);
 	innerSimulation.force('collide', rectangleCollideForce());
 
-	const useRadialLayout = nodes.length > 0 && nodes.reduce((a: number, item) => item?.members?.length > 0 ? a + 1 : a, 0) === 0;
+	const useRadialLayout = nodes.length > 2 && nodes.reduce((a: number, item) => item?.members?.length > 0 ? a + 1 : a, 0) === 0;
 	if (useRadialLayout) {
 		innerSimulation.force('charge', d3.forceManyBody().strength(-3000));
 		innerSimulation.force('radial', radialClampForce(
-			() => 0.5*parentNode.width,
-			() => 0.5*parentNode.height,
 			() => {
 				const res = nodes.reduce((a: number, node) => a + Math.sqrt(node.width ** 2 + node.height ** 2), 0) / (Math.PI * 2);
-				return res + drawSettings.minimumVertexSize; // Offset for small circles (2 nodes)
+				const radius = res + 2 * drawSettings.minimumVertexSize; // Offset for small circles (2 nodes)
+				return radius;
 			},
 		));
 	} else {
@@ -174,7 +173,7 @@ export function draw(
 	simulation.force('charge', d3.forceManyBody().strength(-3000));
 	simulation.force('x', d3.forceX(SVGSIZE / 2));
 	simulation.force('y', d3.forceY(SVGSIZE / 2));
-	simulation.force('collide', rectangleCollideForce(graphData.nodes))
+	simulation.force('collide', rectangleCollideForce())
 	simulation.on('tick', () => {
 		masterSimulationTicked(
 			graphData,

--- a/svelte/src/routes/v2/scripts/draw/index.ts
+++ b/svelte/src/routes/v2/scripts/draw/index.ts
@@ -332,11 +332,6 @@ export function draw(
 		//@ts-ignore
 		d3
 			.zoom()
-			.extent([
-				[0, 0],
-				[SVGSIZE + SVGMARGIN * 2, SVGSIZE + SVGMARGIN * 2]
-			])
-			//.scaleExtent([1, 8]) Our dataset is way larger
 			.on('zoom', ({ transform }) => {
 				canvas.attr('transform', transform);
 				drawSettings.transformation = transform;


### PR DESCRIPTION
Implement nested lay-out

The inner lay-out is a radial lay-out, outer lay-out doesn't do much (yet). Michel suggested to try a tree layout on the outer layer

Bugs are still present when dragging nodes (not that is was bug-free anyway), But since the inner layout fixes the nodes in a circle, we might want to reconsider the expansion/contraction behaviour of the nodes.

Though there is still some work to do, it would be great if this could be merged to prevent further conflicts down the line.

(this also contains a bugfix for the collision force)