### PR TITLE
fix: move initialize routing to every redraw, lifting doesn't lift grandchild

### DIFF
--- a/svelte/src/scripts/create-graph-data/index.ts
+++ b/svelte/src/scripts/create-graph-data/index.ts
@@ -106,10 +106,7 @@ export function createGraphData(convertedData: ConvertedData): GraphData {
 		node.incomingLinksLifted = [];
 	});
 
-	// Initialize links
-	links.forEach(link => {
-		link.routing = [];
-	});
+	
 
 	const graphDataLinks = assignOutgoingIncomingLinksAndOriginalLiftedSourceTargetReference(
 		//@ts-expect-error GraphDataEdge is still a ConvertedEdge

--- a/svelte/src/scripts/draw/index.ts
+++ b/svelte/src/scripts/draw/index.ts
@@ -25,6 +25,11 @@ export function draw(
 		n.height = notNaN(drawSettings.minimumNodeSize);
 	});
 
+	// Initialize links routing
+	graphData.links.forEach(link => {
+		link.routing = [];
+	});
+
 	// Calculate layouts for non-simple nodes
 
 	innerNodes.forEach(n => layerTreeLayout(drawSettings, n.members, n, {edgeRouting: true}));

--- a/svelte/src/scripts/draw/layouts.ts
+++ b/svelte/src/scripts/draw/layouts.ts
@@ -5,11 +5,11 @@ import {notNaN} from '$helper';
 
 type GraphDataNodeExt = GraphDataNode & {width: number; height: number};
 type TreeNode = GraphDataNodeExt & {next: TreeNode[]};
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type NodeLayout = (
 	drawSettings: DrawSettingsInterface,
 	childNodes: GraphDataNode[],
 	parentNode?: GraphDataNode,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	options?: any,
 ) => void;
 

--- a/svelte/src/scripts/filter/lift-edges.ts
+++ b/svelte/src/scripts/filter/lift-edges.ts
@@ -31,5 +31,9 @@ export function redirectAllEdgeToDestinationNode(
 		redirectDestination.incomingLinks.push(...nodeToBeRedirected.incomingLinks);
 		nodeToBeRedirected.outgoingLinks = [];
 		nodeToBeRedirected.incomingLinks = [];
+
+		nodeToBeRedirected.members?.forEach(member => {
+			redirectAllEdgeToDestinationNode(redirectDestination, member, sensitivity);
+		});
 	}
 }


### PR DESCRIPTION
based on what I understand, routing is repopulated each time doRelayout. to so it should be cleared before before each layout computation. 

I notice this when there's a bug when do trigger relayout. (for example by lifting depedencies)